### PR TITLE
always update attrImageZoomSrc on ezpModel change

### DIFF
--- a/js/angular-ezplus.js
+++ b/js/angular-ezplus.js
@@ -129,6 +129,7 @@
                         }
 
                         initialUrl = getInitialUrl(options, smallUrl);
+                        $element.data($scope.ezpOptions.attrImageZoomSrc || 'zoom-image', $scope.ezpModel.large || '');
                         plugin.swaptheimage(initialUrl, largeUrl);
                         showZoom();
                     } else {
@@ -142,7 +143,7 @@
                             $element.attr('src', initialUrl);
                         }
 
-                        $element.attr('data-zoom-image', largeUrl);
+                        $element.data($scope.ezpOptions.attrImageZoomSrc || 'zoom-image', $scope.ezpModel.large || '');
 
                         preparePlugin($element, options);
                     }


### PR DESCRIPTION
when ezpOptions changes the plugin is recreated and then reads the
attrImageZoomSrc attribute to get the zoom image

the attrImageZoomSrc is set on the element where the directive is applied,
so we need to update the attribute even if the plugin is already created

closes #13 
